### PR TITLE
Fix: Add missing questionnaire coding criteria columns for all groups

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lucar
 Title: Prepare Survey Data from LUCA Office
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(
     person("Steffen", "Brandt", email="steffen@opencampus.sh",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0001-5410-7186")))

--- a/R/get_questionnaire_elements.R
+++ b/R/get_questionnaire_elements.R
@@ -31,7 +31,9 @@ get_questionnaire_elements <- function (json_data) {
                                  binaryFileId=NA_character_, fileId=NA_character_, emailId=NA_character_,
                                  questions_freetextQuestionCodingCriteria_id=NA_character_, questions_freetextQuestionCodingCriteria_description=NA_character_,
                                  questions_freetextQuestionCodingCriteria_score=NA_character_, maxDurationInSeconds=NA_character_,
-                                 questions_freeTextAnswer=NA_character_, questions_answers_id=NA_character_)
+                                 questions_freeTextAnswer=NA_character_, questions_answers_id=NA_character_,
+                                 questions_freetextQuestionCodingCriteria__id=NA_character_, questions_freetextQuestionCodingCriteria__description=NA_character_,
+                                 questions_freetextQuestionCodingCriteria__score=NA_character_)
 
 
   questionnaire_data <- json_data$questionnaires %>%
@@ -83,6 +85,7 @@ get_questionnaire_elements <- function (json_data) {
             answer_category_description = dplyr::coalesce(
               questions_answers__text,
               questions_freetextQuestionCodingCriteria_description,
+              questions_freetextQuestionCodingCriteria__description,
             )
           )
       } else {
@@ -128,4 +131,5 @@ globalVariables(c("questions", "id", "questions_answers", "questions_freetextQue
                   "questions_isAdditionalFreeTextAnswerEnabled", "answer_category_id",
                   "answer_category_description", "questions_answers_isCorrect",
                   "questions_freetextQuestionCodingCriteria_score", "questions_position",
-                  "questions_freetextQuestionCodingCriteria__id", "questions_freetextQuestionCodingCriteria__score"))
+                  "questions_freetextQuestionCodingCriteria__id", "questions_freetextQuestionCodingCriteria__description",
+                  "questions_freetextQuestionCodingCriteria__score"))


### PR DESCRIPTION
- Added double-underscore versions of freetextQuestionCodingCriteria fields to needed_variables
- Ensures columns exist (with NA) for all participants, even when some don't have coding criteria
- Fixes error: 'Objekt questions_freetextQuestionCodingCriteria__id nicht gefunden'
- Version bump to 0.2.2